### PR TITLE
Filechooser Improvments

### DIFF
--- a/LSDPatcher.java
+++ b/LSDPatcher.java
@@ -30,6 +30,7 @@ import javax.swing.UIManager;
 
 import structures.LSDJFont;
 import utils.FontIO;
+import utils.GlobalHolder;
 
 public class LSDPatcher {
 
@@ -65,6 +66,7 @@ public class LSDPatcher {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+		GlobalHolder.set(new File(System.getProperty("user.dir")), File.class, "JFileChooser");
 		new LSDPatcher();
 	}
 

--- a/MainWindow.java
+++ b/MainWindow.java
@@ -106,6 +106,8 @@ public class MainWindow extends JFrame {
     GridLayout gridLayout1 = new GridLayout();
 
     JMenuBar menuBar = new JMenuBar();
+    
+    File previousPath = null;
 
     public class SampleCanvas extends Canvas {
         byte[] buf;
@@ -172,7 +174,7 @@ public class MainWindow extends JFrame {
     }
 
     public MainWindow() {
-        enableEvents(AWTEvent.WINDOW_EVENT_MASK);
+    	enableEvents(AWTEvent.WINDOW_EVENT_MASK);
         try {
             jbInit();
         }
@@ -495,12 +497,15 @@ public class MainWindow extends JFrame {
     	chooser.addChoosableFileFilter(filter);
     	chooser.setFileFilter(filter);
     	chooser.setDialogTitle("Load ROM image");
+    	if (previousPath != null)
+    		chooser.setCurrentDirectory(previousPath);
     	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{
     		File f = chooser.getSelectedFile();
     		if (f != null) {
     			loadRom(f);
+    			previousPath = f.getParentFile();
     		}    		
     	}
     }
@@ -718,6 +723,8 @@ public class MainWindow extends JFrame {
     	chooser.setDialogTitle("Select ROM to import from");
     	chooser.addChoosableFileFilter(filter);
     	chooser.setFileFilter(filter);
+    	if (previousPath != null)
+    		chooser.setCurrentDirectory(previousPath);
 
        	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
@@ -727,8 +734,8 @@ public class MainWindow extends JFrame {
 	        if (f == null) {
 	            return;
 	        }
-
-        importKits(f);
+	        previousPath = f.getParentFile();
+	        importKits(f);
     	}
 	}
 
@@ -739,12 +746,15 @@ public class MainWindow extends JFrame {
     	chooser.setApproveButtonMnemonic(JFileChooser.SAVE_DIALOG);
     	chooser.addChoosableFileFilter(filter);
     	chooser.setFileFilter(filter);
-    	
+    	if (previousPath != null)
+    		chooser.setCurrentDirectory(previousPath);
+
        	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{ 
 	        try {
 	            File f = chooser.getSelectedFile();
+		        previousPath = f.getParentFile();
 	
 	            romFile = new RandomAccessFile(f,"rw");
 	            romFile.write(romImage);
@@ -763,13 +773,15 @@ public class MainWindow extends JFrame {
     	chooser.setApproveButtonMnemonic(JFileChooser.SAVE_DIALOG);
     	chooser.addChoosableFileFilter(filter);
     	chooser.setFileFilter(filter);
+    	if (previousPath != null)
+    		chooser.setCurrentDirectory(previousPath);
     	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{
 
     		try {
     			File f = chooser.getSelectedFile();
-    			
+    			previousPath = f.getParentFile();
     			byte buf[]=new byte[0x4000];
     			int offset=getROMOffsetForSelectedBank();
     			RandomAccessFile bankFile=new RandomAccessFile(f,"rw");

--- a/MainWindow.java
+++ b/MainWindow.java
@@ -59,6 +59,9 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 import fontEditor.FontEditor;
 import utils.GlobalHolder;
+import utils.JFileChooserFactory;
+import utils.JFileChooserFactory.FileOperation;
+import utils.JFileChooserFactory.FileType;
 
 public class MainWindow extends JFrame {
 	private static final long serialVersionUID = -3993608561466542956L;
@@ -491,13 +494,7 @@ public class MainWindow extends JFrame {
     }
 
     void selectRomToLoad() {
-    	FileFilter filter = new FileNameExtensionFilter("Game Boy ROM", "gb");
-    	JFileChooser chooser = new JFileChooser("Load ROM Image");
-    	chooser.setApproveButtonMnemonic(JFileChooser.OPEN_DIALOG);
-    	chooser.addChoosableFileFilter(filter);
-    	chooser.setFileFilter(filter);
-    	chooser.setDialogTitle("Load ROM image");
-		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
+    	JFileChooser chooser = JFileChooserFactory.createChooser("Load ROM Image", FileType.Gb, FileOperation.Load);
     	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{
@@ -716,14 +713,7 @@ public class MainWindow extends JFrame {
     }
 
     void importKits_actionPerformed(ActionEvent e) {
-    	FileFilter filter = new FileNameExtensionFilter("Game Boy ROM (*.gb)", "gb");
-    	JFileChooser chooser = new JFileChooser();
-    	chooser.setApproveButtonMnemonic(JFileChooser.OPEN_DIALOG);
-    	chooser.setDialogTitle("Select ROM to import from");
-    	chooser.addChoosableFileFilter(filter);
-    	chooser.setFileFilter(filter);
-		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
-
+    	JFileChooser chooser = JFileChooserFactory.createChooser("Select ROM to import from", FileType.Gb, FileOperation.Load);
        	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{
@@ -738,13 +728,7 @@ public class MainWindow extends JFrame {
 	}
 
     void saveROMButton_actionPerformed() {
-    	FileFilter filter = new FileNameExtensionFilter("Game Boy ROM (*.gb)", "gb");
-    	JFileChooser chooser = new JFileChooser();
-    	chooser.setDialogTitle("Save ROM image");
-    	chooser.setApproveButtonMnemonic(JFileChooser.SAVE_DIALOG);
-    	chooser.addChoosableFileFilter(filter);
-    	chooser.setFileFilter(filter);
-		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
+    	JFileChooser chooser = JFileChooserFactory.createChooser("Save ROM image", FileType.Gb, FileOperation.Save);
 
        	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
@@ -765,12 +749,8 @@ public class MainWindow extends JFrame {
     }
 
     void exportKitButton_actionPerformed() {
-    	FileFilter filter = new FileNameExtensionFilter("LSDJ Kit (*.kit)", "kit");
-    	JFileChooser chooser = new JFileChooser("Export kit");
-    	chooser.setApproveButtonMnemonic(JFileChooser.SAVE_DIALOG);
-    	chooser.addChoosableFileFilter(filter);
-    	chooser.setFileFilter(filter);
-		GlobalHolder.get(File.class, "JFileChooser");
+    	JFileChooser chooser = JFileChooserFactory.createChooser("Export kit", FileType.Kit, FileOperation.Save);
+
     	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{

--- a/MainWindow.java
+++ b/MainWindow.java
@@ -58,9 +58,11 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import fontEditor.FontEditor;
+import utils.GlobalHolder;
 
 public class MainWindow extends JFrame {
-    String versionString = "LSD-Patcher v1.1.4";
+	private static final long serialVersionUID = -3993608561466542956L;
+	String versionString = "LSD-Patcher v1.1.4";
     JPanel contentPane;
     JPanel jPanel1 = new JPanel();
     TitledBorder titledBorder1;
@@ -107,8 +109,6 @@ public class MainWindow extends JFrame {
 
     JMenuBar menuBar = new JMenuBar();
     
-    File previousPath = null;
-
     public class SampleCanvas extends Canvas {
         byte[] buf;
 
@@ -497,15 +497,14 @@ public class MainWindow extends JFrame {
     	chooser.addChoosableFileFilter(filter);
     	chooser.setFileFilter(filter);
     	chooser.setDialogTitle("Load ROM image");
-    	if (previousPath != null)
-    		chooser.setCurrentDirectory(previousPath);
+		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
     	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{
     		File f = chooser.getSelectedFile();
     		if (f != null) {
     			loadRom(f);
-    			previousPath = f.getParentFile();
+    			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
     		}    		
     	}
     }
@@ -723,8 +722,7 @@ public class MainWindow extends JFrame {
     	chooser.setDialogTitle("Select ROM to import from");
     	chooser.addChoosableFileFilter(filter);
     	chooser.setFileFilter(filter);
-    	if (previousPath != null)
-    		chooser.setCurrentDirectory(previousPath);
+		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
 
        	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
@@ -734,7 +732,7 @@ public class MainWindow extends JFrame {
 	        if (f == null) {
 	            return;
 	        }
-	        previousPath = f.getParentFile();
+			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
 	        importKits(f);
     	}
 	}
@@ -746,15 +744,14 @@ public class MainWindow extends JFrame {
     	chooser.setApproveButtonMnemonic(JFileChooser.SAVE_DIALOG);
     	chooser.addChoosableFileFilter(filter);
     	chooser.setFileFilter(filter);
-    	if (previousPath != null)
-    		chooser.setCurrentDirectory(previousPath);
+		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
 
        	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{ 
 	        try {
 	            File f = chooser.getSelectedFile();
-		        previousPath = f.getParentFile();
+    			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
 	
 	            romFile = new RandomAccessFile(f,"rw");
 	            romFile.write(romImage);
@@ -773,15 +770,14 @@ public class MainWindow extends JFrame {
     	chooser.setApproveButtonMnemonic(JFileChooser.SAVE_DIALOG);
     	chooser.addChoosableFileFilter(filter);
     	chooser.setFileFilter(filter);
-    	if (previousPath != null)
-    		chooser.setCurrentDirectory(previousPath);
+		GlobalHolder.get(File.class, "JFileChooser");
     	int result = chooser.showOpenDialog(this);
     	if (result == JFileChooser.APPROVE_OPTION)
     	{
 
     		try {
     			File f = chooser.getSelectedFile();
-    			previousPath = f.getParentFile();
+    			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
     			byte buf[]=new byte[0x4000];
     			int offset=getROMOffsetForSelectedBank();
     			RandomAccessFile bankFile=new RandomAccessFile(f,"rw");

--- a/PaletteEditor.java
+++ b/PaletteEditor.java
@@ -22,7 +22,12 @@ import java.awt.BorderLayout;
 import java.awt.EventQueue;
 
 import java.awt.event.KeyEvent;
+import java.io.File;
+
 import javax.swing.filechooser.FileNameExtensionFilter;
+
+import utils.GlobalHolder;
+
 import javax.swing.JFileChooser;
 import javax.swing.JMenuBar;
 import javax.swing.JMenu;
@@ -817,9 +822,12 @@ public class PaletteEditor
 		JFileChooser chooser = new JFileChooser();
 		FileNameExtensionFilter filter = new FileNameExtensionFilter("LSDj Palette", "lsdpal");
 		chooser.setFileFilter(filter);
+		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
 		int returnVal = chooser.showOpenDialog(this);
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
-			loadPalette(chooser.getSelectedFile());
+            File f = chooser.getSelectedFile();
+			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
+			loadPalette(f);
 		}
     }
 
@@ -829,9 +837,12 @@ public class PaletteEditor
 		chooser.setFileFilter(filter);
         String paletteName = paletteSelector.getSelectedItem().toString();
         chooser.setSelectedFile(new java.io.File(paletteName + ".lsdpal"));
+		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
 		int returnVal = chooser.showSaveDialog(this);
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
-			String filename = chooser.getSelectedFile().toString();
+            File f = chooser.getSelectedFile();
+			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
+			String filename = f.toString();
 			if (!filename.endsWith("lsdpal")) {
 				filename += ".lsdpal";
 			}

--- a/fontEditor/FontEditor.java
+++ b/fontEditor/FontEditor.java
@@ -421,6 +421,7 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 		try {
 			JFileChooser chooser = new JFileChooser();
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("LSDj Font", "lsdfnt");
+			chooser.addChoosableFileFilter(filter);
 			chooser.setFileFilter(filter);
 			int returnVal = chooser.showOpenDialog(this);
 			if (returnVal == JFileChooser.APPROVE_OPTION) {

--- a/fontEditor/FontEditor.java
+++ b/fontEditor/FontEditor.java
@@ -26,6 +26,9 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 import utils.FontIO;
 import utils.GlobalHolder;
+import utils.JFileChooserFactory;
+import utils.JFileChooserFactory.FileOperation;
+import utils.JFileChooserFactory.FileType;
 
 public class FontEditor extends JFrame implements java.awt.event.ItemListener, java.awt.event.ActionListener,
 		FontMap.TileSelectListener, TileEditor.TileChangedListener {
@@ -420,11 +423,7 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 
 	void showOpenDialog() {
 		try {
-			JFileChooser chooser = new JFileChooser();
-			FileNameExtensionFilter filter = new FileNameExtensionFilter("LSDj Font", "lsdfnt");
-			chooser.addChoosableFileFilter(filter);
-			chooser.setFileFilter(filter);
-			chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
+	    	JFileChooser chooser = JFileChooserFactory.createChooser("Open Font", FileType.Lsdfnt, FileOperation.Load);
 			int returnVal = chooser.showOpenDialog(this);
 			if (returnVal == JFileChooser.APPROVE_OPTION) {
 				File f = chooser.getSelectedFile();
@@ -444,7 +443,7 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 
 	void showSaveDialog() {
 		try {
-			JFileChooser chooser = new JFileChooser();
+	    	JFileChooser chooser = JFileChooserFactory.createChooser("Save Font", FileType.Lsdfnt, FileOperation.Save);
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("LSDj Font", "lsdfnt");
 			chooser.setFileFilter(filter);
 			String fontName = fontSelector.getSelectedItem().toString();
@@ -469,10 +468,7 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 
 	void importBitmap() {
 		// File Choose
-		JFileChooser chooser = new JFileChooser();
-		FileNameExtensionFilter filter = new FileNameExtensionFilter("Bitmap (*.bmp)", "bmp");
-		chooser.setFileFilter(filter);
-		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
+    	JFileChooser chooser = JFileChooserFactory.createChooser("Import Font Image", FileType.Png, FileOperation.Load);
 		int returnVal = chooser.showOpenDialog(this);
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			File bitmap = chooser.getSelectedFile();
@@ -498,17 +494,14 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 	}
 
 	void exportBitmap() {
-		JFileChooser chooser = new JFileChooser();
-		FileNameExtensionFilter filter = new FileNameExtensionFilter("Bitmap (*.bmp)", "bmp");
-		chooser.setFileFilter(filter);
-		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
+    	JFileChooser chooser = JFileChooserFactory.createChooser("Export Font Image", FileType.Png, FileOperation.Save);
 		int returnVal = chooser.showOpenDialog(this);
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			File f = chooser.getSelectedFile();
 			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
 			String filename = f.toString();
-			if (!filename.endsWith("bmp")) {
-				filename += ".bmp";
+			if (!filename.endsWith("png")) {
+				filename += ".png";
 			}
 			BufferedImage image = tileEditor.createImage();
 
@@ -533,7 +526,7 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 				}
 			}
 			try {
-				ImageIO.write(image, "BMP", new File(filename));
+				ImageIO.write(image, "PNG", new File(filename));
 			} catch (IOException e) {
 				JOptionPane.showMessageDialog(this, "Couldn't export the fontmap.\n" + e.getMessage());
 				e.printStackTrace();

--- a/fontEditor/FontEditor.java
+++ b/fontEditor/FontEditor.java
@@ -25,6 +25,7 @@ import javax.swing.JPanel;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import utils.FontIO;
+import utils.GlobalHolder;
 
 public class FontEditor extends JFrame implements java.awt.event.ItemListener, java.awt.event.ActionListener,
 		FontMap.TileSelectListener, TileEditor.TileChangedListener {
@@ -423,10 +424,13 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("LSDj Font", "lsdfnt");
 			chooser.addChoosableFileFilter(filter);
 			chooser.setFileFilter(filter);
+			chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
 			int returnVal = chooser.showOpenDialog(this);
 			if (returnVal == JFileChooser.APPROVE_OPTION) {
+				File f = chooser.getSelectedFile();
+    			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
 				String fontName;
-				fontName = FontIO.loadFnt(chooser.getSelectedFile(), romImage, selectedFontOffset);
+				fontName = FontIO.loadFnt(f, romImage, selectedFontOffset);
 				tileEditor.generateShadedAndInvertedTiles();
 				setFontName(fontSelector.getSelectedIndex(), fontName);
 				tileEditor.tileChanged();
@@ -445,13 +449,16 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 			chooser.setFileFilter(filter);
 			String fontName = fontSelector.getSelectedItem().toString();
 			chooser.setSelectedFile(new java.io.File(fontName + ".lsdfnt"));
+			chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
 			int returnVal = chooser.showSaveDialog(this);
 			if (returnVal == JFileChooser.APPROVE_OPTION) {
-				String filename = chooser.getSelectedFile().toString();
+				File f = chooser.getSelectedFile();
+    			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
+				String filename = f.toString();
 				if (!filename.endsWith("lsdfnt")) {
 					filename += ".lsdfnt";
 				}
-				FontIO.saveFnt(chooser.getSelectedFile(), fontName, romImage, selectedFontOffset);
+				FontIO.saveFnt(f, fontName, romImage, selectedFontOffset);
 
 			}
 		} catch (IOException e) {
@@ -465,9 +472,11 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 		JFileChooser chooser = new JFileChooser();
 		FileNameExtensionFilter filter = new FileNameExtensionFilter("Bitmap (*.bmp)", "bmp");
 		chooser.setFileFilter(filter);
+		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
 		int returnVal = chooser.showOpenDialog(this);
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			File bitmap = chooser.getSelectedFile();
+			GlobalHolder.set(bitmap.getParentFile(), File.class, "JFileChooser");
 			try {
 				BufferedImage image = ImageIO.read(bitmap);
 				if (image.getWidth() != 64 && image.getHeight() != 72) {
@@ -492,9 +501,12 @@ public class FontEditor extends JFrame implements java.awt.event.ItemListener, j
 		JFileChooser chooser = new JFileChooser();
 		FileNameExtensionFilter filter = new FileNameExtensionFilter("Bitmap (*.bmp)", "bmp");
 		chooser.setFileFilter(filter);
+		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
 		int returnVal = chooser.showOpenDialog(this);
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
-			String filename = chooser.getSelectedFile().toString();
+			File f = chooser.getSelectedFile();
+			GlobalHolder.set(f.getParentFile(), File.class, "JFileChooser");
+			String filename = f.toString();
 			if (!filename.endsWith("bmp")) {
 				filename += ".bmp";
 			}

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,1 +1,6 @@
 /FontIO.class
+/SingletonHolder.class
+/Singleton.class
+/Singleton$Holder.class
+/GlobalHolder$Holder.class
+/GlobalHolder.class

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -4,3 +4,6 @@
 /Singleton$Holder.class
 /GlobalHolder$Holder.class
 /GlobalHolder.class
+/JFileChooserFactory.class
+/JFileChooserFactory$FileType.class
+/JFileChooserFactory$FileOperation.class

--- a/utils/GlobalHolder.java
+++ b/utils/GlobalHolder.java
@@ -5,11 +5,13 @@ import java.util.Map;
 
 /**
  * Singletons is an useful template but it does have one big issue: it doesnn't
- * comply with the Single Responsability Principle as it both holds an instance
+ * comply with the Single Responsibility Principle as it both holds an instance
  * and manages its lifetime.
  * 
  * This class only offers a way to store and access a global instance as long as
- * the using code manages the lifetime of said global
+ * the using code manages the lifetime of said global.
+ * Allows for using a kind-of namespace and class override,
+ * providing the overriding class is a child of the given object.
  * 
  * @author Florian Dormont
  *
@@ -27,13 +29,34 @@ public class GlobalHolder {
 		globals.put(object.getClass().getCanonicalName(), object);
 	}
 
+	public static <C> void set(C object, Class<C> cls) {
+		lazyInstanciation();
+		globals.put(cls.getCanonicalName(), object);
+	}
+	
+	public static <C> void set(C object, Class<C> cls, String namespace) {
+		lazyInstanciation();
+		globals.put(namespace + "::" + cls.getCanonicalName(), object);
+	}
+	
+	public static void set(Object object, String namespace) {
+		lazyInstanciation();
+		globals.put(namespace + "::" + object.getClass().getCanonicalName(), object);
+	}
+
 	@SuppressWarnings("unchecked")
-	public static <C> C get(Class<?> cls) {
+	public static <C> C get(Class<C> cls) {
 		lazyInstanciation();
 		return (C) globals.get(cls.getCanonicalName());
 	}
 
-	public static <C> C release(Class<?> cls) {
+	@SuppressWarnings("unchecked")
+	public static <C> C get(Class<C> cls, String namespace) {
+		lazyInstanciation();
+		return (C) globals.get(namespace + "::" + cls.getCanonicalName());
+	}
+
+	public static <C> C release(Class<C> cls) {
 		lazyInstanciation();
 		C c = get(cls);
 		globals.put(c.getClass().getCanonicalName(), null);

--- a/utils/GlobalHolder.java
+++ b/utils/GlobalHolder.java
@@ -1,0 +1,43 @@
+package utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Singletons is an useful template but it does have one big issue: it doesnn't
+ * comply with the Single Responsability Principle as it both holds an instance
+ * and manages its lifetime.
+ * 
+ * This class only offers a way to store and access a global instance as long as
+ * the using code manages the lifetime of said global
+ * 
+ * @author Florian Dormont
+ *
+ */
+public class GlobalHolder {
+	static private Map<String, Object> globals = null;
+
+	private static void lazyInstanciation() {
+		if (globals == null)
+			globals = new HashMap<String, Object>();
+	}
+
+	public static void set(Object object) {
+		lazyInstanciation();
+		globals.put(object.getClass().getCanonicalName(), object);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <C> C get(Class<?> cls) {
+		lazyInstanciation();
+		return (C) globals.get(cls.getCanonicalName());
+	}
+
+	public static <C> C release(Class<?> cls) {
+		lazyInstanciation();
+		C c = get(cls);
+		globals.put(c.getClass().getCanonicalName(), null);
+		return c;
+	}
+
+}

--- a/utils/JFileChooserFactory.java
+++ b/utils/JFileChooserFactory.java
@@ -1,0 +1,62 @@
+package utils;
+
+import java.io.File;
+
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+public class JFileChooserFactory {
+	public enum FileType {
+		Gb, Lsdfnt, Lsdpal, Kit,
+		// Misc
+		Wav, Png
+
+	}
+
+	public enum FileOperation {
+		Save, Load, MultipleLoad
+	}
+
+	public static JFileChooser createChooser(String windowTitle, FileType type, FileOperation operation) {
+		JFileChooser chooser = new JFileChooser();
+		chooser.setDialogTitle(windowTitle);
+		FileFilter filter = null;
+		switch (type) {
+		case Gb:
+			filter = new FileNameExtensionFilter("Game Boy ROM (*.gb)", "gb");
+			break;
+		case Lsdfnt:
+			filter = new FileNameExtensionFilter("LSDJ Font (*.lsdfnt)", "lsdfnt");
+			break;
+		case Lsdpal:
+			filter = new FileNameExtensionFilter("LSDJ Palette (*.lsdpal)", "lsdpal");
+			break;
+		case Kit:
+			filter = new FileNameExtensionFilter("LSDJ Kit (*.kit)", "kit");
+			break;
+		case Wav:
+			filter = new FileNameExtensionFilter("Wave file (*.wav)", "wav");
+			break;
+		case Png:
+			filter = new FileNameExtensionFilter("PNG / Portable Network Graphics (*.png)", "png");
+			break;
+		default:
+			filter = new FileNameExtensionFilter("Game Boy ROM (*.gb)", "gb");
+			break;
+		}
+		chooser.addChoosableFileFilter(filter);
+		chooser.setFileFilter(filter);
+
+		chooser.setCurrentDirectory(GlobalHolder.get(File.class, "JFileChooser"));
+
+		if (operation == FileOperation.Save)
+			chooser.setApproveButtonMnemonic(JFileChooser.SAVE_DIALOG);
+		else
+			chooser.setApproveButtonMnemonic(JFileChooser.OPEN_DIALOG);
+
+		chooser.setMultiSelectionEnabled(operation == FileOperation.MultipleLoad);
+
+		return chooser;
+	}
+}


### PR DESCRIPTION
Fixing both [this issue](https://github.com/jkotlinski/lsdpatch/issues/27) and #2 except for the the it won't remember the folder through different executions of the program.

I'm just not really happy on how the GlobalHolder look. Inspired by some trick I learnt with C++ experience, I tried to apply it on Java, only to face generic programming limitations on Java. The result look a bit silly but it works as expected.

The last step is probably remembering the path through instance through [the Preferences API](http://docs.oracle.com/javase/8/docs/technotes/guides/preferences/overview.html). Now to determine if I should not use GlobalHolder anymore (and eventually remove it) and just interface with the API directly for every case a JFileChooser is used.