### PR TITLE
Kit editor refresh

### DIFF
--- a/src/main/java/kitEditor/KitEditor.java
+++ b/src/main/java/kitEditor/KitEditor.java
@@ -44,8 +44,6 @@ import static java.lang.Character.toUpperCase;
 public class KitEditor extends JFrame {
     private static final long serialVersionUID = -3993608561466542956L;
     private JPanel contentPane;
-    private final JPanel jPanel1 = new JPanel();
-    //JLabel fileNameLabel = new JLabel();
     private int prevBankBoxIndex = -1;
     private final JComboBox<String> bankBox = new JComboBox<>();
     private final JList<String> instrList = new JList<>();
@@ -87,15 +85,13 @@ public class KitEditor extends JFrame {
 
     private final JMenuBar menuBar = new JMenuBar();
 
-    private final Sound soundPlayer = new Sound();
-
-    class KitFileFilter implements java.io.FilenameFilter {
+    static class KitFileFilter implements java.io.FilenameFilter {
         public boolean accept(java.io.File dir, String name) {
             return name.toLowerCase().endsWith(".kit");
         }
     }
 
-    class WavFileFilter implements java.io.FilenameFilter {
+    static class WavFileFilter implements java.io.FilenameFilter {
         public boolean accept(java.io.File dir, String name) {
             return name.toLowerCase().endsWith(".wav");
         }

--- a/src/main/java/kitEditor/KitEditor.java
+++ b/src/main/java/kitEditor/KitEditor.java
@@ -259,8 +259,8 @@ public class KitEditor extends JFrame {
         saveROMButton.setEnabled(false);
         saveROMButton.setText("Save ROM");
 
-        contentPane.add(new JLabel("Kit Edition"), "growx");
-        contentPane.add(new JLabel("Sample Edition"), "growx,wrap");
+        contentPane.add(new JLabel("Kit Edit"), "growx");
+        contentPane.add(new JLabel("Sample Edit"), "growx,wrap");
 
         contentPane.add(kitContainer, "grow, cell 0 1, spany");
         contentPane.add(addSampleButton, "split 3");

--- a/src/main/java/utils/SampleCanvas.java
+++ b/src/main/java/utils/SampleCanvas.java
@@ -21,6 +21,8 @@ public class SampleCanvas extends Canvas {
         double w = g.getClipBounds().getWidth();
         double h = g.getClipBounds().getHeight();
 
+        g.setColor(Color.black);
+        g.fillRect(0, 0, (int)w, (int)h);
         if (buf == null) {
             return;
         }


### PR DESCRIPTION
This is currently a partial reorganization of the kit editor panel as I was displeased on how kit and sample operations were mixed together.

This became a two-panel-ish UI where kit operations and sample operations are grouped in visual parts instead of having a big op list.

Also it tackles on #40 as there is now a field to rename the current kit and one for the current sample.

The remaining stuff to do here visually would be to make the operation verbs consistent (add or load, not both, add or replace actions but not both) to make UI discovery less surprising.

Making the PR has no real sense, I'm just making this to see if people are interested and to provide a temporary build in another place than in a Discord server (even if I like hanging out there)

[Link to the WIP build](https://github.com/Eiyeron/lsdpatch/files/3722540/lsdpatch-redux-1.4.2a.jar.zip)

![image](https://user-images.githubusercontent.com/936086/81143719-cad19d00-8f72-11ea-802c-26d8cea18222.png)
